### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ argskwargs
 ``argskwargs`` is a small Python library that provides a flexible container for
 positional and keyword arguments.
 
-* Documentation: https://argskwargs.readthedocs.org/
+* Documentation: https://argskwargs.readthedocs.io/
 
 * Python Package Index (PyPI): https://pypi.python.org/pypi/argskwargs/
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
